### PR TITLE
why chrome send request twice

### DIFF
--- a/src/WsServer.cpp
+++ b/src/WsServer.cpp
@@ -138,6 +138,7 @@ WsServer::readEvent(struct kevent* curEvent)
 				EV_ADD | EV_ENABLE, 0, 0, NULL);
 		// addEvents(clientSock.getSocketFd(), EVFILT_WRITE,
 		//         EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, NULL);
+
 		std::cout << "client socket[" << clientSock.getSocketFd() << "] created, server read finish ";
 		std::cout << "now client socket size : " << m_clientSock.size() << std::endl;
 		return (1);

--- a/src/socket/WsASocket.hpp
+++ b/src/socket/WsASocket.hpp
@@ -27,8 +27,7 @@ class WsASocket
 			struct sockaddr_in	m_SocketAddr;
 			socklen_t			m_SocketAddrSize;
 			int					m_SocketFd;
-			int					m_epollFd;
-			char				m_buffer[BUF_SIZE];
+			// char				m_buffer[BUF_SIZE];
 			// std::string			m_readBuffer;
 
 		public:

--- a/src/socket/WsClientSock.cpp
+++ b/src/socket/WsClientSock.cpp
@@ -67,6 +67,7 @@ WsClientSock::readSock(void)
 		m_readBuffer += buffer;
 		if (readRet < BUF_SIZE)
 		{
+			std::cout << "read size : " << readRet << std::endl;
 			WsRequest request;
 			m_method = request.readRequest(m_readBuffer);
 			if (0)

--- a/src/socket/WsResponse.cpp
+++ b/src/socket/WsResponse.cpp
@@ -208,7 +208,7 @@ void WsResponse::makeEntityHeader(void)
 	// chuncked (응답헤더)
 	// 동적으로 생성되어 Body의 길이를 모르는 경우에 조금씩 전송이 가능하다.
 	// 각 chunk 마다 그 시작에 16진수 길이를 삽입하여 chunk 길이를 알려준다.
-	m_responseBuf += "Content-Type: text/html, text/css; charset=UTF-8\n";
+	m_responseBuf += "Content-Type: text/css, text/html; charset=UTF-8\n";
 	// m_responseBuf += "Content-Disposition: attachment; filename=soum.html";
 	m_responseBuf += "Content-Disposition: inline\n";
 }


### PR DESCRIPTION
tcp packets could be caused by "Predict network actions to improve page load performance" setting. so my webserv create unnecessary client socket that do not anything

but favicon request send to working client socket that created original request it's chrome problem and safari works good

but safari send favicon request after created new client socket that only read favicon request