### PR TITLE
[soum] change WsIMethod class 

### DIFF
--- a/src/method/WsDeleteMethod.cpp
+++ b/src/method/WsDeleteMethod.cpp
@@ -1,14 +1,14 @@
-#include "WsPutMethod.hpp"
+#include "WsDeleteMethod.hpp"
 
-WsPutMethod::WsPutMethod(const std::string& readLine)
+WsDeleteMethod::WsDeleteMethod(const std::string& readLine)
 	:WsIMethod(readLine)
 {}
 
-WsPutMethod::~WsPutMethod()
+WsDeleteMethod::~WsDeleteMethod()
 {
 }
 
-void WsPutMethod::loadRequest(const std::string &readLine)
+void WsDeleteMethod::loadRequest(const std::string &readLine)
 {
 	if (readLine[0] == ' ')
 		return ;
@@ -16,9 +16,10 @@ void WsPutMethod::loadRequest(const std::string &readLine)
 	splittedLine[0].pop_back();
 	for (size_t vecIdx = 1; vecIdx < splittedLine.size(); vecIdx++)
 		m_requestSet[splittedLine[0]].push_back(splittedLine[vecIdx]);
+
 }
 
-void WsPutMethod::printBody(void) const
+void WsDeleteMethod::printBody(void) const
 {
 	std::cout << "no body" << std::endl;
 }

--- a/src/method/WsDeleteMethod.hpp
+++ b/src/method/WsDeleteMethod.hpp
@@ -1,0 +1,16 @@
+#ifndef WsDeleteMethod_hpp
+#define WsDeleteMethod_hpp
+
+#include "WsIMethod.hpp"
+
+class WsDeleteMethod : public WsIMethod
+{
+	public:
+		WsDeleteMethod(const std::string& readLine);
+		virtual ~WsDeleteMethod();
+
+		virtual void	loadRequest(const std::string &readLine);
+		virtual void	printBody(void) const;
+
+};
+#endif //WsDeleteMethod_hpp

--- a/src/method/WsGetMethod.cpp
+++ b/src/method/WsGetMethod.cpp
@@ -8,3 +8,19 @@ WsGetMethod::~WsGetMethod()
 {
 
 }
+
+void
+WsGetMethod::loadRequest(const std::string &readLine)
+{
+	if (readLine[0] == ' ')
+		return ;
+	std::vector<std::string> splittedLine(splitReadLine(readLine, ","));
+	splittedLine[0].pop_back();
+	for (size_t vecIdx = 1; vecIdx < splittedLine.size(); vecIdx++)
+		m_requestSet[splittedLine[0]].push_back(splittedLine[vecIdx]);
+}
+
+void WsGetMethod::printBody(void) const
+{
+	std::cout << "no body" << std::endl;
+}

--- a/src/method/WsGetMethod.hpp
+++ b/src/method/WsGetMethod.hpp
@@ -9,5 +9,8 @@ class WsGetMethod : public WsIMethod
 		WsGetMethod(const std::string& readLine);
 		~WsGetMethod();
 
+		virtual void 	loadRequest(const std::string &readLine);
+		virtual void	printBody(void) const;
+
 };
 #endif //WsGetMethod_hpp

--- a/src/method/WsIMethod.cpp
+++ b/src/method/WsIMethod.cpp
@@ -22,15 +22,20 @@ WsIMethod::WsIMethod(const std::string& readLine)
 WsIMethod::~WsIMethod()
 {}
 
-void WsIMethod::loadRequest(const std::string& readLine)
-{
-	if (readLine[0] == ' ')
-		return ;
-	std::vector<std::string> splittedLine(splitReadLine(readLine, ","));
-	splittedLine[0].pop_back();
-	for (size_t vecIdx = 1; vecIdx < splittedLine.size(); vecIdx++)
-		m_requestSet[splittedLine[0]].push_back(splittedLine[vecIdx]);
-}
+// void WsIMethod::loadRequest(const std::string& readLine)
+// {
+	// if (readLine[0] == '\r')
+	//     m_isBody = true;
+	// if (readLine[0] == ' ')
+	//     return ;
+    //
+	// if (m_isBody)
+	//     return (loadBody(readLine));
+	// std::vector<std::string> splittedLine(splitReadLine(readLine, ","));
+	// splittedLine[0].pop_back();
+	// for (size_t vecIdx = 1; vecIdx < splittedLine.size(); vecIdx++)
+	//     m_requestSet[splittedLine[0]].push_back(splittedLine[vecIdx]);
+// }
 
 std::vector<std::string>
 WsIMethod::splitReadLine(const std::string& readLine, const std::string& str)
@@ -105,5 +110,3 @@ WsIMethod::checkStartLine(std::vector<std::string>& splittedLine)
     //	return (501);				// Not Implemented
 	return (0);
 }
-
-

--- a/src/method/WsIMethod.cpp
+++ b/src/method/WsIMethod.cpp
@@ -2,12 +2,21 @@
 
 WsIMethod::WsIMethod(const std::string& readLine)
 {
+
 	std::vector<std::string> splittedLine;
+	m_statusCode = 0;
+	m_method = "";
+	m_uri = "";
+	m_httpVersion = "";
 
 	splittedLine = splitReadLine(readLine);
-	m_method = splittedLine[0];
-	m_uri = splittedLine[1];
-	m_httpVersion = splittedLine[2];
+	m_statusCode = checkStartLine(splittedLine);
+	if (!m_statusCode)
+	{
+		m_method = splittedLine[0];
+		m_uri = splittedLine[1];
+		m_httpVersion = splittedLine[2];
+	}
 }
 
 WsIMethod::~WsIMethod()
@@ -15,7 +24,10 @@ WsIMethod::~WsIMethod()
 
 void WsIMethod::loadRequest(const std::string& readLine)
 {
+	if (readLine[0] == ' ')
+		return ;
 	std::vector<std::string> splittedLine(splitReadLine(readLine, ","));
+	splittedLine[0].pop_back();
 	for (size_t vecIdx = 1; vecIdx < splittedLine.size(); vecIdx++)
 		m_requestSet[splittedLine[0]].push_back(splittedLine[vecIdx]);
 }
@@ -54,7 +66,7 @@ void WsIMethod::printInfo(void) const
 	mapIt = m_requestSet.begin();
 	for (; mapIt != m_requestSet.end(); mapIt++)
 	{
-		std::cout << mapIt->first << std::endl;
+		std::cout << mapIt->first << " :"<< std::endl;
 		for (size_t setIdx = 0; setIdx < mapIt->second.size(); setIdx++)
 			std::cout << "\t" << mapIt->second.at(setIdx) << std::endl;
 	}
@@ -75,6 +87,23 @@ const std::map<std::string, std::vector<std::string> >&
 WsIMethod::getRequestSet(void) const
 {
 	return (m_requestSet);
+}
+
+int
+WsIMethod::checkStartLine(std::vector<std::string>& splittedLine)
+{
+	// TODO
+	// uri max length check & request-line length check
+
+	if (splittedLine.size() != 3)
+		return (400);				// Bad Request
+	// if (splittedLine[1].size() > maxUriLen)
+	// 	return (414);				// URI Too Long
+	if (splittedLine[2] != "HTTP/1.1\r")
+		return (400);				// Bad Request
+	// if (splittedLine[0].size() + splittedLine[1].size() + splittedLine[2].size() + 2 > maxReqLen)
+    //	return (501);				// Not Implemented
+	return (0);
 }
 
 

--- a/src/method/WsIMethod.hpp
+++ b/src/method/WsIMethod.hpp
@@ -16,10 +16,12 @@ class WsIMethod
 		std::string m_method;
 		std::string m_uri;
 		std::string m_httpVersion;
-
 		std::map<std::string, std::vector<std::string> > m_requestSet;
-		std::vector<std::string> splitReadLine(const std::string& readLine,
+		int			m_statusCode;
+
+		std::vector<std::string>	splitReadLine(const std::string& readLine,
 				const std::string& str = " ");
+		int							checkStartLine(std::vector<std::string>& splittedLine);
 
 	public:
 		WsIMethod(const std::string& readLine);

--- a/src/method/WsIMethod.hpp
+++ b/src/method/WsIMethod.hpp
@@ -16,21 +16,25 @@ class WsIMethod
 		std::string m_method;
 		std::string m_uri;
 		std::string m_httpVersion;
-		std::map<std::string, std::vector<std::string> > m_requestSet;
+		std::map<std::string, std::vector<std::string> >
+					m_requestSet;
 		int			m_statusCode;
 
 		std::vector<std::string>	splitReadLine(const std::string& readLine,
 				const std::string& str = " ");
 		int							checkStartLine(std::vector<std::string>& splittedLine);
+		void						loadBody(const std::string& readLine);
 
 	public:
 		WsIMethod(const std::string& readLine);
 		virtual ~WsIMethod();
 
-		void				loadRequest(const std::string& readLine);
+		virtual void		loadRequest(const std::string& readLine) = 0;
+		virtual void		printBody(void) const = 0;
+
 		void				printInfo(void) const;
 		const std::string&	getUri(void) const;
-		const std::string&getHttpVersion(void) const;
+		const std::string&	getHttpVersion(void) const;
 		const std::map<std::string, std::vector<std::string> >&
 							getRequestSet(void) const;
 

--- a/src/method/WsPostMethod.cpp
+++ b/src/method/WsPostMethod.cpp
@@ -2,8 +2,38 @@
 
 WsPostMethod::WsPostMethod(const std::string& readLine)
 	:WsIMethod(readLine)
-{}
+{
+	m_isBody = false;
+	m_bodyBuffer.clear();
+}
 
 WsPostMethod::~WsPostMethod()
+{}
+
+void
+WsPostMethod::loadRequest(const std::string &readLine)
 {
+	std::cout << "post load request function" << std::endl;
+	if (readLine[0] == '\r')
+		m_isBody = true;
+	if (readLine[0] == ' ')
+		return ;
+	if (m_isBody)
+		return (loadBody(readLine));
+	std::vector<std::string> splittedLine(splitReadLine(readLine, ","));
+	splittedLine[0].pop_back();
+	for (size_t vecIdx = 1; vecIdx < splittedLine.size(); vecIdx++)
+		m_requestSet[splittedLine[0]].push_back(splittedLine[vecIdx]);
+}
+
+void
+WsPostMethod::loadBody(const std::string& readLine)
+{
+	m_bodyBuffer += readLine;
+}
+
+void
+WsPostMethod::printBody(void) const
+{
+	std::cout << m_bodyBuffer << std::endl;
 }

--- a/src/method/WsPostMethod.hpp
+++ b/src/method/WsPostMethod.hpp
@@ -5,8 +5,17 @@
 
 class WsPostMethod : public WsIMethod
 {
+	private:
+		bool		m_isBody;
+		std::string	m_bodyBuffer;
+
+		void	loadBody(const std::string& readLine);
+
 	public:
 		WsPostMethod(const std::string& method);
 		~WsPostMethod();
+
+		virtual void	loadRequest(const std::string& readLine);
+		void			printBody(void) const;
 };
 #endif //WsPostMethod_hpp

--- a/src/method/WsPutMethod.hpp
+++ b/src/method/WsPutMethod.hpp
@@ -7,8 +7,9 @@ class WsPutMethod : public WsIMethod
 {
 	public:
 		WsPutMethod(const std::string& readLine);
-		~WsPutMethod();
+		virtual ~WsPutMethod();
 
-
+		virtual void	loadRequest(const std::string &readLine);
+		virtual void	printBody(void) const;
 };
 #endif //WsPutMethod_hpp

--- a/src/socket/WsASocket.hpp
+++ b/src/socket/WsASocket.hpp
@@ -29,6 +29,7 @@ class WsASocket
 			int					m_SocketFd;
 			// char				m_buffer[BUF_SIZE];
 			// std::string			m_readBuffer;
+			//
 
 		public:
 			// Orthodox Canonical Form

--- a/src/socket/WsClientSock.cpp
+++ b/src/socket/WsClientSock.cpp
@@ -70,7 +70,7 @@ WsClientSock::readSock(void)
 			std::cout << "read size : " << readRet << std::endl;
 			WsRequest request;
 			m_method = request.readRequest(m_readBuffer);
-			if (0)
+			if (1)
 				m_method->printInfo();
 			m_readFinish = true;
 			m_readBuffer.clear();

--- a/src/socket/WsRequest.cpp
+++ b/src/socket/WsRequest.cpp
@@ -43,6 +43,12 @@ WsRequest::methodGenerator(const std::string& readLine)
 		return (new WsPostMethod(readLine));
 	else if (method == "PUT")
 		return (new WsPutMethod(readLine));
+
+	// TODO
+	// else if (method == "DELETE")
+	//     return (new WsPutMethod(readLine));
+	// else
+	//     thow error;
 	return (NULL);
 }
 

--- a/src/socket/http_message_grammar.txt
+++ b/src/socket/http_message_grammar.txt
@@ -1,0 +1,58 @@
+[3. Message Format]
+HTTP-message	=	start-line
+					*(header-field CRLF)
+					CRLF
+					[ message-body ]
+
+HTTP 메시지를 분석하는 일반적인 절차는 start-line을 읽고
+각 헤더 필드를 빈 행까지 필드 이름으로 해시테이블로 읽은다음
+분석된 데이터를 사용하여 메시지 본문이 필요한지 여부를 확인한다.
+
+메시지 본분이 표시된경우
+메시지 본문 길이와 동일한 octet의 양을 읽거나 커넥션을 닫을 때까지 스트림으로 읽는다.
+
+수신자는 반드시 HTTP 메시지를 US-ASCII의 상위집합인 인코딩에서 octet으로 구문분석 해야한다.(MUST)
+
+HTTP 메시지는 스트림으로 구문분석하여 증분처리하거나 다운스트림으로 전송할 수 있다.
+	*증분처리 : 기존 데이터가 이미 처리되었을때
+				전체 데이터 세트를 다시 처리하지 않고
+				데이터 세트에 새로 추가된 데이터 파티션만 처리하는 처리방법
+
+발신자는 start-line과 첫번째 헤더 필드 사이에 공백을 보내면 안된다.(MUST NOT)
+start-liner과 첫번째 헤더 필드 사이의 공백을 수신하면 메시지를 유효하지 않은 것으로 거부
+하거나 메시지를 더이상 처리하지 않고 각 공백이 지정된 줄을 소비해야한다(MUST)
+	*i.e :	공백이 오는 모든 후속 줄과 함께 올바르게 형성된 헤더 필드가 수신되거나
+			헤더 부분이 끝날 때까지 전체 라인을 무시한다.
+
+[3.1 Start Line]
+
+요청과 응답 두 유형의 메시지는 start-line(요청) status-line(응답)과
+메시지 본문의 길이를 결정하기 위한 알고리즘만 다르다.
+서버와 클라이언트는 다른 start-line 형식으로 구분할수 있지만
+서버는 요청만, 클라이언트는 응답만을 예상하도록 구현된다.
+
+[3.1.1 Request Line]
+
+request-line은 method 토큰을 시작으로 공백(SP), request-target, 공백(SP), 프로토콜 버전, CRLF를 끝으로 한다.
+
+request-line	= method SP request-target SP HTTP-version CRLF
+
+method 토큰은 대상 리소스를 실행하기 위한 요청 메서드를 표시한다.
+요청 메서드는 대 소문자를 구분한다.
+
+세 구성요소에는 공백이 허용되지 않기 때문에
+일반적으로 수신자는 공백을 분할하여 request-line을 구성 요소 부분으로 분할한다.
+
+유효하지 않은 request-line의 수신자는 400(Bad Request) 오류 또는
+301(Moved Permanently) 리다이렉트로 응답해야 하며,
+request-target은 적절히 인코딩되어야 한다.(SHOULD)
+수신자는 리다이렉트 없이 요청을 자동 수정하고 처리해서는 안된다.(SHOULD NOT)
+
+request-line의 길이에 대해 미리 정의된 제한을 두지 않는다.
+구현한 것보다 더 긴 메서드를 수신한 서버는 501(Not Implemented)상태코드로 응답해야 한다.(SHOULD)
+request-target을 구문분석하려는 URI보다 긴 414(URI TOO Long)상태 코드로 응답해야한다.(MUST)
+
+모든 HTTP 발신자와 수신자는 최소 8000 octet 길이의 request-line을 지원 하는것을 권장한다.(RECOMMENDED)
+
+[3.1.2 Status Line]
+


### PR DESCRIPTION
 - 메소드 마다 request message의 body의 유무가 다름 
 - post method는 body가 있기 때문에 loadRequest 함수에서 다른 방식으로 처리해야함 
 - 따라서 WsIMethod의 멤버 함수 loadRequest를 순수 가상함수로 만듦 
 - 각각의 메소드는 다른 loadRequest 함수 호출가능 
 - WsPostMethod에 body를 저장할 m_bodyBuffer 멤버 변수 추가  
 
- WsDeleteMethod 클래스 추가