### PR TITLE
feature : AMethod::extractExt(), AMethod::getFileExt() 추가

### DIFF
--- a/config/webserv_test.conf
+++ b/config/webserv_test.conf
@@ -17,7 +17,7 @@ server {
 
 		alias /Users/soum/webserv/html/put_test;
 
-		limit_except PUT;
+		limit_except PUT POST;
 	}
 
 	location /bla/ {

--- a/src/method/AMethod.cpp
+++ b/src/method/AMethod.cpp
@@ -185,4 +185,20 @@ AMethod::directoryParse(std::string& uri,
 	}
 }
 
+void
+AMethod::extractExt(std::string& fileName)
+{
+	size_t dotPos;
+
+	dotPos = fileName.find(".");
+	m_fileExt = "";
+	if (dotPos != std::string::npos)
+		m_fileExt = fileName.substr(dotPos);
+}
+
+const std::string&
+AMethod::getFileExt(void) const
+{
+	return (m_fileExt);
+}
 

--- a/src/method/AMethod.hpp
+++ b/src/method/AMethod.hpp
@@ -40,6 +40,7 @@ class AMethod
 		bool						checkFileExists(const std::string& filePath);
 		bool						checkDirExists(const std::string& filePath);
 		int							hexToDecimal(const std::string& readLine);
+		void						extractExt(std::string& fileName);
 
 	public:
 		// constructor & destructor
@@ -60,7 +61,7 @@ class AMethod
 		void							queryStringParse(std::string& uri);
 		void							directoryParse(std::string& uri,
 													   std::vector<std::string>& dirVec);
-		void							printInfo(void) const;
+
 
 		int								getStatusCode(void) const;
 		const std::string&				getMethod(void) const;
@@ -71,6 +72,7 @@ class AMethod
 										getRequestSet(void) const;
 		const std::string&				getFilePath(void) const;
 		const std::string&				getQueryString(void) const;
+		const std::string&				getFileExt(void) const;
 
 };
 #endif //AMethod_hpp

--- a/src/method/getMethod.cpp
+++ b/src/method/getMethod.cpp
@@ -119,6 +119,7 @@ getMethod::uriParse(void)
 	}
 	if (fileName == "")
 		fileName = indexFile[0];
+	extractExt(fileName);
 	m_filePath = root + fileName;
 	m_statusCode = 200;
 

--- a/src/socket/clientSocket.cpp
+++ b/src/socket/clientSocket.cpp
@@ -73,9 +73,6 @@ clientSocket::readSock(std::fstream& logFile, int msgSize)
 		logFile << "client socket close!" << std::endl;
 	else
 	{
-		// m_readBuffer += buffer;
-		if (readRet == BUF_SIZE)
-			return (readRet);
 		requestStatus = m_request.readRequest(buffer);
 		if (requestStatus == READING)
 			return (readRet);
@@ -87,55 +84,6 @@ clientSocket::readSock(std::fstream& logFile, int msgSize)
 			m_readFinish = true;
 			m_readBuffer.clear();
 		}
-		// TODO
-		// chunked 일때 처리
-
-		// if (m_readBuffer.rfind("\r\n\r\n") == std::string::npos)
-		// {
-		//     return readRet;
-		// }
-		// else if (is_bodySection == false && \
-		//     m_readBuffer.rfind("\r\n\r\n") != std::string::npos)
-		// {
-		//     std::cout << "Found carrage return!" << std::endl;
-		//     request request(m_conf);
-		//     m_method = request.readRequest(m_readBuffer);
-		//     if (m_method->getMethod() == "POST")
-		//     {
-		//         //postMethod* 	tempPost = dynamic_cast<postMethod*>(m_method);
-		//         //tempPost->loadBody(m_readBuffer);
-		//         std::cout << "m_body is : " << m_method->getBody() << std::endl;
-		//         std::map<std::string, std::vector<std::string> >::const_iterator transferIt;
-		//         transferIt = m_method->getRequestSet().find("Transfer-Encoding");
-		//         std::string type;
-		//         if (transferIt != m_method->getRequestSet().end())
-		//         {
-		//             type = transferIt->second[0];
-		//         }
-		//         if (type == "chunked" && type.find("0\n") == std::string::npos)
-		//         {
-		//             is_bodySection = true;
-		//             return readRet;
-		//         }
-		//     }
-		//     if (m_method->getMethod() != "POST")
-		//     {
-		//         is_bodySection = false;
-		//         std::cout << *m_method << std::endl;
-		//         m_method->printBody();
-		//     }
-		//     m_readFinish = true;
-		//     m_readBuffer.clear();
-		// }
-		// else if (is_bodySection == true && \
-		//     m_readBuffer.rfind("\r\n\r\n") != std::string::npos)
-		// {
-		//     std::cout << *m_method << std::endl;
-		//     m_method->printBody();
-		//     m_readFinish = true;
-		//     is_bodySection = false;
-		//     m_readBuffer.clear();
-		// }
 	}
 	return (readRet);
 }
@@ -154,7 +102,14 @@ clientSocket::sendSock(std::fstream& logFile)
 		logFile << "-------------------------------" << RESET << std::endl;
 	}
 	sendRet = write(m_SocketFd, response().c_str(), response.getBufSize());
-	m_method = NULL;
+
+	// TODO
+	// just test!
+	if (m_method->getMethod() == "PUT" || m_method->getMethod() == "POST")
+	{
+		m_method = NULL;
+		return (-1);
+	}
 	return (sendRet);
 }
 

--- a/src/socket/request.cpp
+++ b/src/socket/request.cpp
@@ -35,12 +35,10 @@ request::readRequest(const std::string& request)
 	}
 	readLine = m_buffer.substr(prePos, m_buffer.size() - prePos);
 	m_buffer.clear();
-	// m_method->loadRequest(readLine);
 	m_buffer += readLine;
 	if (m_method && m_method->isMethodCreateFin())
 	{
 		m_method->uriParse();
-
 		return (READ_FIN);
 	}
 	return (READING);

--- a/src/socket/response.cpp
+++ b/src/socket/response.cpp
@@ -63,18 +63,6 @@ response::makeBody(void)
 }
 
 void
-response::extractExt()
-{
-	std::string filepath = m_filePath;
-
-	while (filepath.find("/") != std::string::npos)
-	{
-		filepath.erase(0, filepath.find("/") + 1);
-	}
-	m_fileExt = filepath.substr(filepath.find("."));
-}
-
-void
 response::parseBody()
 {
 	if (m_newBody.find("Content-type:") != std::string::npos)
@@ -121,21 +109,31 @@ response::makeResponse(const AMethod* method)
 	cgi defaultCgi;
 
 	m_method = method;
+	m_fileExt = method->getFileExt();
 
-	makeStatusLine();
-	extractExt();
-	makeResponseHeader();
-	makeGeneralHeader();
-	m_isCgi = checkIsCgi();
-	if (m_isCgi == 1)
+	if (method->getMethod() != "PUT")
 	{
-		defaultCgi.initCgi(m_method);
-		m_newBody = defaultCgi.execCgi(m_method);
-		//std::cout << m_newBody << std::endl;
+		makeStatusLine();
+		makeResponseHeader();
+		makeGeneralHeader();
+		m_isCgi = checkIsCgi();
+		if (m_isCgi == 1)
+		{
+			defaultCgi.initCgi(m_method);
+			m_newBody = defaultCgi.execCgi(m_method);
+		}
+		parseBody();
+		makeEntityHeader();
+		makeBody();
+
 	}
-	parseBody();
-	makeEntityHeader();
-	makeBody();
+	else
+	{
+		makeStatusLine();
+		makeResponseHeader();
+		makeGeneralHeader();
+		makeEntityHeader();
+	}
 }
 
 const std::string&

--- a/src/socket/response.hpp
+++ b/src/socket/response.hpp
@@ -31,7 +31,6 @@ class response
 		void				makeResponseHeader(void);
 		void				makeEntityHeader(void);
 		void				makeGeneralHeader(void);
-		void				extractExt(void);
 		void				parseBody(void);
 		const std::string	getDate(void);
 		const std::string	getStatusCodeStr(int statusCode);


### PR DESCRIPTION
- file의 확장자를 response::makeResponse()에서 파싱하지 않음

- 각각의 메소드 uriParse()함수 안에서 extractExt()를 진행

TODO

- PUT, POST 메소드에서 파일 생성 요청이오면 파일 만들어야 함

- .bla 확장자는 cgi_tester를 실행시켜야함

- 특정 확장자를 위한 location block 필요 -> 확장자를 위한 파싱